### PR TITLE
Add features for accessibility

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,8 @@ description: CSCI-UA 480 Student, Spring 2019
 # CUSTOMIZE
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
 avatar: https://avatars1.githubusercontent.com/u/46607804?s=200&v=4
+# fallback text in case image is not served and/or for screen readers
+avatar_alt_text: Avatar
 
 # CUSTOMIZE
 #
@@ -37,7 +39,7 @@ footer-links:
 
 # CUSTOMIZE
 # Your website URL (e.g. https://nyu-ossd-s18.github.io/weekly )
-# Replace the last part by the name of your own repository. 
+# Replace the last part by the name of your own repository.
 # It should be "/USER_NAME-weekly" in which USER_NAME is replaced by your actual
 # user name for GitHub.
 

--- a/_includes/svg-icons.html
+++ b/_includes/svg-icons.html
@@ -1,13 +1,13 @@
-{% if site.footer-links.dribbble %}<a href="https://dribbble.com/{{ site.footer-links.dribbble }}"><i class="svg-icon dribbble"></i></a>{% endif %}
-{% if site.footer-links.email %}<a href="mailto:{{ site.footer-links.email }}"><i class="svg-icon email"></i></a>{% endif %}
-{% if site.footer-links.facebook %}<a href="https://www.facebook.com/{{ site.footer-links.facebook }}"><i class="svg-icon facebook"></i></a>{% endif %}
-{% if site.footer-links.flickr %}<a href="https://www.flickr.com/{{ site.footer-links.flickr }}"><i class="svg-icon flickr"></i></a>{% endif %}
-{% if site.footer-links.github %}<a href="https://github.com/{{ site.footer-links.github }}"><i class="svg-icon github"></i></a>{% endif %}
-{% if site.footer-links.instagram %}<a href="https://instagram.com/{{ site.footer-links.instagram }}"><i class="svg-icon instagram"></i></a>{% endif %}
-{% if site.footer-links.linkedin %}<a href="https://www.linkedin.com/in/{{ site.footer-links.linkedin }}"><i class="svg-icon linkedin"></i></a>{% endif %}
-{% if site.footer-links.pinterest %}<a href="https://www.pinterest.com/{{ site.footer-links.pinterest }}"><i class="svg-icon pinterest"></i></a>{% endif %}
-{% if site.footer-links.rss %}<a href="{{ site.baseurl }}/feed.xml"><i class="svg-icon rss"></i></a>{% endif %}
-{% if site.footer-links.twitter %}<a href="https://www.twitter.com/{{ site.footer-links.twitter }}"><i class="svg-icon twitter"></i></a>{% endif %}
-{% if site.footer-links.stackoverflow %}<a href="http://stackoverflow.com/{{ site.footer-links.stackoverflow }}"><i class="svg-icon stackoverflow"></i></a>{% endif %}
-{% if site.footer-links.youtube %}<a href="https://youtube.com/{{ site.footer-links.youtube }}"><i class="svg-icon youtube"></i></a>{% endif %}
-{% if site.footer-links.googleplus %}<a href="https://plus.google.com/{{ site.footer-links.googleplus }}"><i class="svg-icon googleplus"></i></a>{% endif %}
+{% if site.footer-links.dribbble %}<a href="https://dribbble.com/{{ site.footer-links.dribbble }}"><i class="svg-icon dribbble"></i> <span class="screen-reader-text">Dribbble</span></a>{% endif %}
+{% if site.footer-links.email %}<a href="mailto:{{ site.footer-links.email }}"><i class="svg-icon email"></i> <span class="screen-reader-text">Email</span></a>{% endif %}
+{% if site.footer-links.facebook %}<a href="https://www.facebook.com/{{ site.footer-links.facebook }}"><i class="svg-icon facebook"></i> <span class="screen-reader-text">Facebook</span></a>{% endif %}
+{% if site.footer-links.flickr %}<a href="https://www.flickr.com/{{ site.footer-links.flickr }}"><i class="svg-icon flickr"></i> <span class="screen-reader-text">Flickr</span></a>{% endif %}
+{% if site.footer-links.github %}<a href="https://github.com/{{ site.footer-links.github }}"><i class="svg-icon github"></i> <span class="screen-reader-text">GitHub</span></a>{% endif %}
+{% if site.footer-links.instagram %}<a href="https://instagram.com/{{ site.footer-links.instagram }}"><i class="svg-icon instagram"></i> <span class="screen-reader-text">Instagram</span></a>{% endif %}
+{% if site.footer-links.linkedin %}<a href="https://www.linkedin.com/in/{{ site.footer-links.linkedin }}"><i class="svg-icon linkedin"></i> <span class="screen-reader-text">LinkedIn</span></a>{% endif %}
+{% if site.footer-links.pinterest %}<a href="https://www.pinterest.com/{{ site.footer-links.pinterest }}"><i class="svg-icon pinterest"></i> <span class="screen-reader-text">Pinterest</span></a>{% endif %}
+{% if site.footer-links.rss %}<a href="{{ site.baseurl }}/feed.xml"><i class="svg-icon rss"></i> <span class="screen-reader-text">RSS</span></a>{% endif %}
+{% if site.footer-links.twitter %}<a href="https://www.twitter.com/{{ site.footer-links.twitter }}"><i class="svg-icon twitter"></i> <span class="screen-reader-text">Twitter</span></a>{% endif %}
+{% if site.footer-links.stackoverflow %}<a href="http://stackoverflow.com/{{ site.footer-links.stackoverflow }}"><i class="svg-icon stackoverflow"></i> <span class="screen-reader-text">Stack Overflow</span></a>{% endif %}
+{% if site.footer-links.youtube %}<a href="https://youtube.com/{{ site.footer-links.youtube }}"><i class="svg-icon youtube"></i> <span class="screen-reader-text">YouTube</span></a>{% endif %}
+{% if site.footer-links.googleplus %}<a href="https://plus.google.com/{{ site.footer-links.googleplus }}"><i class="svg-icon googleplus"></i> <span class="screen-reader-text"></span>Google+</a>{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
     <div class="wrapper-masthead">
       <div class="container">
         <header class="masthead clearfix">
-          <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar }}" /></a>
+          <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar }}" alt="{{ site.avatar_alt_text }}"/></a>
 
           <div class="site-info">
             <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,7 @@
   </head>
 
   <body>
+    <a href="#main" class="screen-reader-text">Skip to content</a>
     <div class="wrapper-masthead">
       <div class="container">
         <header class="masthead clearfix">

--- a/style.scss
+++ b/style.scss
@@ -30,6 +30,33 @@ body {
   width: 100%;
 }
 
+.screen-reader-text {
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  word-wrap: normal !important;
+  /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+  &:focus {
+    clip: auto !important;
+    clip-path: none;
+    color: white;
+    display: block;
+    height: auto;
+    left: 0;
+    line-height: normal;
+    text-decoration: none;
+    top: 0;
+    width: 100%;
+    z-index: 100000;
+  }
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: $helveticaNeue;
   color: $darkerGray;
@@ -299,7 +326,7 @@ table {
     border: 1px solid #eee;
     padding: 10px;
   }
-} 
+}
 
 
 // Settled on moving the import of syntax highlighting to the bottom of the CSS

--- a/style.scss
+++ b/style.scss
@@ -43,10 +43,28 @@ body {
   word-wrap: normal !important;
   /* Many screen reader and browser combinations announce broken words as they would appear visually. */
   &:focus {
+    position: static !important;
     clip: auto !important;
     clip-path: none;
-    color: white;
-    display: block;
+    color: inherit;
+    display: inline;
+    height: auto;
+    left: 0;
+    line-height: normal;
+    text-decoration: none;
+    top: 0;
+    width: 100%;
+    z-index: 100000;
+  }
+}
+
+*:focus {
+  .screen-reader-text {
+    position: static !important;
+    clip: auto !important;
+    clip-path: none;
+    color: inherit;
+    display: inline;
     height: auto;
     left: 0;
     line-height: normal;


### PR DESCRIPTION
This PR adds a few minor changes to the base Jekyll site to help meet the Web Content Accessibility Guidelines. Primarily:
##  Text Alternatives
All non-text content that is not purely decorative should be accompanied by equivalent text content that provides the equivalent purpose or context for non-sighted users. (It's also a good practice for fallback content in case images fail to serve!) This PR adds:
+ An option to set the alt text for the avatar that appears in the site header
+ Captions for the SVG icons used for footer links

## Keyboard Navigation
For users who navigate the web with keyboard controls or with screen-readers, it is often cumbersome to navigate past the identical content that appears in the headers of sites -- to allow these users to easily access the main content of a site it's suggested that a "skip to content" link is provided at the very start of each page that allows a user to skip repeated content. 


# References:
https://www.w3.org/WAI/WCAG21/quickref/#non-text-content
https://www.w3.org/WAI/WCAG21/quickref/#link-purpose-in-context
https://www.w3.org/WAI/WCAG21/quickref/#link-purpose-link-only
https://www.w3.org/TR/WCAG20-TECHS/G1.html
https://webaim.org/techniques/css/invisiblecontent/
https://webaim.org/techniques/skipnav/